### PR TITLE
Saving multiplies the amount by 100

### DIFF
--- a/assets/js/acf-price-v4.js
+++ b/assets/js/acf-price-v4.js
@@ -2,7 +2,9 @@
 
     function initialize_field( $el ) {
         var $input = $el.find('input');
-        $input.number( true, $input.data('format-decimals'), $input.data('format-decimal_point'), $input.data('format-thousands_separator') );
+		var val = $input.val();
+		$input.number(true, $input.data('format-decimals'), $input.data('format-decimal_point'), $input.data('format-thousands_separator') );
+		$input.val(val);
     }
 
     $(document).on('acf/setup_fields', function(e, postbox){

--- a/assets/js/acf-price-v5.js
+++ b/assets/js/acf-price-v5.js
@@ -2,7 +2,9 @@
 
 	function initialize_field( $el ) {
 		var $input = $el.find('input');
-		$input.number( true, $input.data('format-decimals'), $input.data('format-decimal_point'), $input.data('format-thousands_separator') );
+		var val = $input.val();
+		$input.number(true, $input.data('format-decimals'), $input.data('format-decimal_point'), $input.data('format-thousands_separator') );
+		$input.val(val);
 	}
 
 	acf.add_action('ready append', function( $el ) {

--- a/fields/acf-price-common.php
+++ b/fields/acf-price-common.php
@@ -49,6 +49,15 @@ abstract class acf_price_common extends acf_field
         return $value;
     }
 
+    public function load_value( $value, $post_id, $field ) 
+    {
+        if ( empty( $value ) ) {
+            $value = 0;
+        }
+        
+        return $value;
+    }
+    
     public function format_value( $value, $post_id, $field )
     {
         $format = $this->parse_format( $field['format'] );
@@ -59,4 +68,5 @@ abstract class acf_price_common extends acf_field
 
         return number_format( $value, $format['decimals'], $format['decimal_point'], $format['thousands_separator'] );
     }
+
 }


### PR DESCRIPTION
The number library needs to load the data without formatting, but can be initialized only once. So here is a workaround.

Fixes #11